### PR TITLE
Add support for blueprint proofing

### DIFF
--- a/src/github.com/getnelson/nelson/blueprint.go
+++ b/src/github.com/getnelson/nelson/blueprint.go
@@ -1,0 +1,61 @@
+//: ----------------------------------------------------------------------------
+//: Copyright (C) 2018 Verizon.  All Rights Reserved.
+//:
+//:   Licensed under the Apache License, Version 2.0 (the "License");
+//:   you may not use this file except in compliance with the License.
+//:   You may obtain a copy of the License at
+//:
+//:       http://www.apache.org/licenses/LICENSE-2.0
+//:
+//:   Unless required by applicable law or agreed to in writing, software
+//:   distributed under the License is distributed on an "AS IS" BASIS,
+//:   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//:   See the License for the specific language governing permissions and
+//:   limitations under the License.
+//:
+//: ----------------------------------------------------------------------------
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"github.com/parnurzeal/gorequest"
+	"strconv"
+)
+
+/*
+ * {
+ *   "content": "CAgICAgIHBsYW5zOg0KICAgICAgICAgIC0gZGVmYXVsdA=="
+ * }
+ */
+type ProofBlueprintWire struct {
+	Content string `json:"content"`
+}
+
+func ProofBlueprint(req ProofBlueprintWire, http *gorequest.SuperAgent, cfg *Config) (res string, err []error) {
+	r, body, errs := AugmentRequest(http.Post(cfg.Endpoint+"/v1/blueprints/proof"), cfg).Send(req).EndBytes()
+
+	if errs != nil {
+		return "", errs
+	}
+
+	if r.StatusCode/100 == 2 {
+		var result ProofBlueprintWire
+		if err := json.Unmarshal(body, &result); err != nil {
+			errs = append(errs, err)
+		}
+
+		data, err := base64.StdEncoding.DecodeString(result.Content)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		// bytes, err := fmt.Printf("%q\n", data)
+		debased := string(data[:])
+
+		return debased, errs
+	} else {
+		errs = append(errs, errors.New("Unexpected response from Nelson server: HTTP status "+strconv.Itoa(r.StatusCode)))
+		return "", errs
+	}
+}

--- a/src/github.com/getnelson/nelson/login.go
+++ b/src/github.com/getnelson/nelson/login.go
@@ -18,8 +18,8 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/parnurzeal/gorequest"
-	"strings"
 )
 
 type CreateSessionRequest struct {
@@ -71,8 +71,10 @@ func createSession(client *gorequest.SuperAgent, githubToken string, baseURL str
 		errStrs := make([]string, len(errs))
 		for i, e := range errs {
 			errStrs[i] = e.Error()
+			fmt.Print(e.Error())
 		}
-		panic(strings.Join(errStrs, "\n"))
+
+		return errs[0], Session{}
 	}
 
 	var result Session

--- a/src/github.com/getnelson/nelson/main.go
+++ b/src/github.com/getnelson/nelson/main.go
@@ -125,6 +125,48 @@ func main() {
 				return nil
 			},
 		},
+		////////////////////////////// BLUEPRINTS //////////////////////////////////
+		{
+			Name:    "blueprints",
+			Aliases: []string{"bp", "blueprint"},
+			Usage:   "Set of commands for working with Nelson blueprints",
+			Subcommands: []cli.Command{
+				{
+					Name:  "proof",
+					Usage: "Given a blueprint template, have Nelson generate an example rendered output",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:        "source, file, f",
+							Value:       "",
+							Usage:       "The blueprint template file to proof",
+							Destination: &selectedManifest,
+						},
+					},
+					Action: func(c *cli.Context) error {
+						if len(selectedManifest) <= 0 {
+							return cli.NewExitError("No blueprint template file specified.", 1)
+						}
+						manifest, err := ioutil.ReadFile(selectedManifest)
+						if err != nil {
+							return cli.NewExitError("Could not read "+selectedManifest, 1)
+						}
+						manifestBase64 := base64.StdEncoding.EncodeToString(manifest)
+						wire := ProofBlueprintWire{Content: manifestBase64}
+						pi.Start()
+						cfg := LoadDefaultConfigOrExit(http)
+						r, e := ProofBlueprint(wire, http, cfg)
+						pi.Stop()
+						if e != nil {
+							return cli.NewExitError("Unable to proof blueprint.", 1)
+						} else {
+							fmt.Println(r)
+							// PrintListDatacenters(r)
+						}
+						return nil
+					},
+				},
+			},
+		},
 		////////////////////////////// DATACENTER //////////////////////////////////
 		{
 			Name:    "datacenters",


### PR DESCRIPTION
Example:

```
λ ./bin/nelson-darwin-amd64 bp proof -f ~/repositories/scala/nelson/core/src/main/resources/nelson/canopus_cron_job.mustache
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  name: "example--1-4-54--2k87sbr5"
  namespace: "dev"
  labels:
    stackName: "example--1-4-54--2k87sbr5"
    unitName: "example"
    version: "1.4.54"
    nelson: "true"
spec:

  schedule: ""
  jobTemplate:
    spec:
      completions: 1
      backoffLimit: 3
      template:
        metadata:
          name: "example--1-4-54--2k87sbr5"
          labels:
            stackName: "example--1-4-54--2k87sbr5"
            unitName: "example"
            version: "1.4.54"
            nelson: "true"
        spec:
          containers:
          - name: "example--1-4-54--2k87sbr5"
            image: "example:1.4"
            env:
            - name: "NELSON_DATACENTER"
              value: "us-east-1"
            - name: "NELSON_ENV"
              value: "dev"
            - name: "NELSON_NAMESPACE"
              value: "dev"
            - name: "NELSON_PLAN"
              value: "default"

            resources:
              requests:
                memory: "512M"
                cpu: 0.5

              limits:
                memory: "512M"
                cpu: 0.5


          restartPolicy: "Never"
```